### PR TITLE
ci: grant write permissions and persist credentials for auto-update R…

### DIFF
--- a/.github/workflows/auto_update_readme.yml
+++ b/.github/workflows/auto_update_readme.yml
@@ -5,16 +5,21 @@ on:
   pull_request_target:
     types: [opened, synchronize]
 
+permissions:
+  contents: write
+
 jobs:
   update-readme:
     runs-on: ubuntu-latest
 
     steps:
-      # 1. Clone the repository and check out the PR branch
+      # 1. Clone the repository using GITHUB_TOKEN with write permissions
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0   # Fetch full history for potential merge operations
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          persist-credentials: true
 
       # 2. Set up the Python environment
       - name: Set up Python
@@ -33,7 +38,7 @@ jobs:
         run: |
           python3 update_readme.py
 
-      # 5. If README.md was modified by the script, commit and push the changes back to the PR branch
+      # 5. Commit and push changes back to the PR branch
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
## What This PR Does

This pull request updates the `auto_update_readme.yml` workflow so that it can push changes to the PR branch. Specifically:

1. Adds `permissions: contents: write` at the top level to ensure `GITHUB_TOKEN` has write access to the repository.
2. Modifies the `actions/checkout@v3` step to include:
   - `token: ${{ secrets.GITHUB_TOKEN }}` to explicitly use the write-capable token.
   - `persist-credentials: true` so that downstream steps can reuse the same token for `git push`.

These changes allow the “Auto Update README” job (triggered via `pull_request_target`) to commit and push updates to `README.md` successfully, without encountering permission errors.

## Why This Is Needed

- Previously, even with `pull_request_target`, the workflow ran with insufficient permissions and `git push` failed with a 403 error.
- By granting `contents: write` and persisting credentials, we ensure the job can push timestamp updates back to the PR branch.

## How to Test

1. Merge this PR into `main` so that `main` contains the updated workflow file.
2. Open or update any new PR against `main` (e.g., push a trivial change).
3. Visit the **Actions** tab of that PR and confirm that the “Auto Update README” job:
   - Runs under the `pull_request_target` event.
   - Executes `update_readme.py` and attempts to commit.
   - Successfully pushes the updated `README.md` back to the PR branch without permission errors.

Once verified, the workflow will automatically refresh the README section with the latest timestamp for all future PRs.